### PR TITLE
Fix check quagga handler

### DIFF
--- a/roles/quagga/handlers/main.yml
+++ b/roles/quagga/handlers/main.yml
@@ -2,7 +2,7 @@
 # This command checks quagga before restarting it, just in case there are syntax
 # errors. The dryrun command will have output if there are problems, so this
 # short shell scripts fails and stops ansible if there is any output.
-- name: check quagga (fail ansible if dry run fails)
+- name: check quagga
   shell: bash -c '[[ -z $(vtysh -f /etc/quagga/Quagga.conf --dryrun) ]]'
 
 # This command actually restarts quagga. This command will actually drop all


### PR DESCRIPTION
Hi,

That's just a fix in the quagga handler name _check quagga_.

```
cumulus@oob-mgmt-server:~/cldemo-rdnbr-ansible$ ansible-playbook run-demo.yml

PLAY [leafs] *******************************************************************

TASK [setup] *******************************************************************
ok: [leaf04]
ok: [leaf01]
ok: [leaf03]
ok: [leaf02]

TASK [ifupdown2 : configure /etc/network/interfaces] ***************************
changed: [leaf01]
changed: [leaf03]
changed: [leaf04]
changed: [leaf02]

TASK [rdnbr : add cl testing repo] *********************************************
changed: [leaf04]
changed: [leaf01]
changed: [leaf03]
changed: [leaf02]

TASK [rdnbr : install rdnbrd] **************************************************
ok: [leaf01]
ok: [leaf02]
ok: [leaf03]
ok: [leaf04]

TASK [rdnbr : run rdnbrd] ******************************************************
changed: [leaf02]
changed: [leaf01]
changed: [leaf04]
changed: [leaf03]

TASK [quagga : ensure quagga is running] ***************************************
changed: [leaf04]
changed: [leaf03]
changed: [leaf02]
changed: [leaf01]

TASK [quagga : configure quagga daemons file] **********************************
ERROR! The requested handler 'check quagga' was not found in any of the known handlers
```

Thanks.